### PR TITLE
feat: 全站共用 layout (header, footer)

### DIFF
--- a/src/components/common/AdminHeader.vue
+++ b/src/components/common/AdminHeader.vue
@@ -1,0 +1,46 @@
+<template>
+    <header class="admin-header">
+        <div class="row">
+            <div class="col-3 header__logo">
+                <h3>聚人</h3>
+                <h6>Attack On Game</h6>
+            </div>
+            <div class="col-6 d-flex align-items-center">
+                <ul class="menu-list">
+                    <li class="menu-list__item">
+                        <router-link>活動列表</router-link>
+                    </li>
+                    <li>這是已登頁面</li>
+                </ul>
+            </div>
+            <div
+                class="col-3 header__nav d-flex justify-content-end align-items-center"
+            >
+                <router-link to="/logout">登出</router-link>
+            </div>
+        </div>
+    </header>
+</template>
+
+<script>
+/**
+ * AdminHeader
+ * @author Vicky
+ * @description 已登頁面共用 Header
+ */
+export default {
+    name: 'AdminHeader',
+};
+</script>
+
+<style lang="scss" scoped>
+.admin-header {
+    .menu-list {
+        display: flex;
+        justify-content: start;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+}
+</style>

--- a/src/components/common/MainFooter.vue
+++ b/src/components/common/MainFooter.vue
@@ -1,0 +1,33 @@
+<template>
+    <footer class="main-footer container-fluid">
+        <div class="row">
+            <div class="col-3">
+                <h3>聚人</h3>
+                <h6>Attack On Game</h6>
+            </div>
+            <div class="col-9"></div>
+        </div>
+    </footer>
+</template>
+
+<script>
+/**
+ * MainFooter
+ * @author vicky
+ * @description 全站共用 MainFooter
+ */
+export default {
+    name: 'MainFooter',
+};
+</script>
+
+<style lang="scss" scoped>
+.main-footer {
+    min-height: 100px;
+    background-color: #180000;
+    padding: 12px 0;
+    position: fixed;
+    bottom: 0;
+    z-index: 1000;
+}
+</style>

--- a/src/components/common/MainHeader.vue
+++ b/src/components/common/MainHeader.vue
@@ -1,0 +1,44 @@
+<template>
+    <div class="main-header">
+        <div class="main-header-content container">
+            <PreLoginHeader v-if="!isLogin" />
+            <AdminHeader v-else />
+        </div>
+    </div>
+</template>
+
+<script>
+import PreLoginHeader from '@/components/common/PreLoginHeader.vue';
+import AdminHeader from '@/components/common/AdminHeader.vue';
+
+/**
+ * MainHeader
+ * @author Vicky
+ * @description 全站共用 MainHeader
+ */
+export default {
+    name: 'MainHeader',
+
+    components: {
+        PreLoginHeader,
+        AdminHeader,
+    },
+
+    props: {
+        isLogin: {
+            type: Boolean,
+            default: false,
+        },
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+.main-header {
+    background-color: #fff6cc;
+    padding: 8px 0;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+}
+</style>

--- a/src/components/common/PreLoginHeader.vue
+++ b/src/components/common/PreLoginHeader.vue
@@ -1,0 +1,47 @@
+<template>
+    <header class="prelogin-header">
+        <div class="row">
+            <div class="col-3 header__logo">
+                <h3>聚人</h3>
+                <h6>Attack On Game</h6>
+            </div>
+            <div class="col-6 d-flex align-items-center">
+                <ul class="menu-list">
+                    <li class="menu-list__item">
+                        <router-link>活動列表</router-link>
+                    </li>
+                    <li>這是未登頁面</li>
+                </ul>
+            </div>
+            <div
+                class="col-3 header__nav d-flex justify-content-end align-items-center"
+            >
+                <router-link to="/login">登入</router-link>
+                <router-link to="/register">註冊</router-link>
+            </div>
+        </div>
+    </header>
+</template>
+
+<script>
+/**
+ * PreLoginHeader
+ * @author Vicky
+ * @description 未登頁面共用 Header
+ */
+export default {
+    name: 'PreLoginHeader',
+};
+</script>
+
+<style lang="scss" scoped>
+.prelogin-header {
+    .menu-list {
+        display: flex;
+        justify-content: start;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,100 +3,108 @@ import { createRouter, createWebHashHistory } from 'vue-router';
 const routes = [
     {
         path: '/',
-        name: 'Index',
-        component: () => import('../views/Index.vue'),
-        children: [],
-    },
-    {
-        path: '/signup',
-        name: 'SignUp',
-        component: () => import('../views/signup/SignUp.vue'),
-    },
-    {
-        path: '/login',
-        name: 'Login',
-        component: () => import('../views/login/Login.vue'),
-    },
-    {
-        // 玩家路由
-        path: '/player',
-        name: 'Player',
-        component: () => import('../views/player/Player.vue'),
+        name: 'Layout',
+        component: () => import('@/views/layout/Layout.vue'),
         children: [
             {
-                path: 'admin',
-                name: 'PlayerAdmin',
-                component: () => import('../views/player/Admin.vue'),
+                path: '/',
+                name: 'Index',
+                component: () => import('@/views/Index.vue'),
+                children: [],
             },
             {
-                path: 'login',
-                name: 'PlayerLogin',
-                component: () => import('../views/player/Login.vue'),
+                path: '/signup',
+                name: 'SignUp',
+                component: () => import('@/views/signup/SignUp.vue'),
             },
             {
-                path: 'signup',
-                name: 'PlayerSignUp',
-                component: () => import('../views/player/SignUp.vue'),
+                path: '/login',
+                name: 'Login',
+                component: () => import('@/views/login/Login.vue'),
             },
             {
-                path: 'form',
-                name: 'PlayerForm',
-                component: () => import('../views/player/Form.vue'),
-            },
-        ],
-    },
-    {
-        // 商家路由
-        path: '/store',
-        name: 'Store',
-        component: () => import('../views/store/Store.vue'),
-        children: [
-            {
-                path: 'admin',
-                name: 'StoreAdmin',
-                component: () => import('../views/store/Admin.vue'),
-            },
-            {
-                path: 'login',
-                name: 'StoreLogin',
-                component: () => import('../views/store/Login.vue'),
-            },
-            {
-                path: 'signup',
-                name: 'StoreSignUp',
-                component: () => import('../views/store/SignUp.vue'),
-            },
-            {
-                path: 'form',
-                name: 'StoreForm',
-                component: () => import('../views/store/Form.vue'),
-            },
-        ],
-    },
-    {
-        path: '/password',
-        name: 'Password',
-        // component: () => import('../views/Password.vue'),
-        children: [
-            {
-                path: 'forget',
-                name: 'PasswordForget',
-                component: () => import('../views/password/PasswordForget.vue'),
+                // 玩家路由
+                path: '/player',
+                name: 'Player',
+                component: () => import('@/views/player/Player.vue'),
+                children: [
+                    {
+                        path: 'admin',
+                        name: 'PlayerAdmin',
+                        component: () => import('@/views/player/Admin.vue'),
+                    },
+                    {
+                        path: 'login',
+                        name: 'PlayerLogin',
+                        component: () => import('@/views/player/Login.vue'),
+                    },
+                    {
+                        path: 'signup',
+                        name: 'PlayerSignUp',
+                        component: () => import('@/views/player/SignUp.vue'),
+                    },
+                    {
+                        path: 'form',
+                        name: 'PlayerForm',
+                        component: () => import('@/views/player/Form.vue'),
+                    },
+                ],
             },
             {
-                path: 'change',
-                name: 'PasswordChange',
-                // component: () => import('../views/password/PasswordChange.vue'),
+                // 商家路由
+                path: '/store',
+                name: 'Store',
+                component: () => import('@/views/store/Store.vue'),
+                children: [
+                    {
+                        path: 'admin',
+                        name: 'StoreAdmin',
+                        component: () => import('@/views/store/Admin.vue'),
+                    },
+                    {
+                        path: 'login',
+                        name: 'StoreLogin',
+                        component: () => import('@/views/store/Login.vue'),
+                    },
+                    {
+                        path: 'signup',
+                        name: 'StoreSignUp',
+                        component: () => import('@/views/store/SignUp.vue'),
+                    },
+                    {
+                        path: 'form',
+                        name: 'StoreForm',
+                        component: () => import('@/views/store/Form.vue'),
+                    },
+                ],
             },
             {
-                path: 'setting',
-                name: 'PasswordSetting',
-                // component: () => import('../views/password/PasswordSetting.vue'),
-            },
-            {
-                path: 'success',
-                name: 'PasswordSuccess',
-                // component:()=>import('../views/password/PasswordSuccess.vue')
+                path: '/password',
+                name: 'Password',
+                // component: () => import('../views/Password.vue'),
+                children: [
+                    {
+                        path: 'forget',
+                        name: 'PasswordForget',
+                        component: () =>
+                            import('@/views/password/PasswordForget.vue'),
+                    },
+                    {
+                        path: 'change',
+                        name: 'PasswordChange',
+                        // component: () => import('../views/password/PasswordChange.vue'),
+                    },
+                    {
+                        path: 'setting',
+                        name: 'PasswordSetting',
+                        // component: () => import('../views/password/PasswordSetting.vue'),
+                    },
+                    {
+                        path: 'success',
+                        name: 'PasswordSuccess',
+                        // component:()=>import('../views/password/PasswordSuccess.vue')
+                    },
+                ],
             },
         ],
     },

--- a/src/views/layout/Layout.vue
+++ b/src/views/layout/Layout.vue
@@ -1,0 +1,30 @@
+<template>
+    <div class="d-flex flex-column min-vh-100">
+        <MainHeader :is-login="isLogin"></MainHeader>
+        <router-view />
+        <MainFooter class="mt-auto"></MainFooter>
+    </div>
+</template>
+
+<script>
+import MainHeader from '@/components/common/MainHeader.vue';
+import MainFooter from '@/components/common/MainFooter.vue';
+
+/**
+ * Layout
+ * @author Vicky
+ * @description 全站共用 Layout
+ */
+export default {
+    name: 'Layout',
+    components: {
+        MainHeader,
+        MainFooter,
+    },
+    data() {
+        return {
+            isLogin: true,
+        };
+    },
+};
+</script>


### PR DESCRIPTION
路由最外層的 '/' 會先進去 `Layout.vue`
透過 `@/views/layout/Layout.vue` 的 isLogin 判斷 Header 要呈現已登 Header or 未登 Header
畫面示意如下~ 
顏色很醜不要打我 🤣

已登
<img width="1433" alt="截圖 2024-05-25 13 57 34" src="https://github.com/hyxfish27/AttackOnGame/assets/80030772/d05fdec4-c706-4d18-adf0-426e3633f8ce">


未登
<img width="1434" alt="截圖 2024-05-25 13 57 55" src="https://github.com/hyxfish27/AttackOnGame/assets/80030772/fff858f7-df2c-4ee1-8912-0ee8ecf3eb54">

