### PR TITLE
Feat:提高登入註冊頁面的好用程度

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -94,3 +94,10 @@ p {
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
 }
+
+.require-icon::before {
+  content: '*';
+  font-size: 0.75rem;
+  color: #dc3545;
+  margin-right: 4px;
+}

--- a/src/components/common/Login.vue
+++ b/src/components/common/Login.vue
@@ -1,45 +1,65 @@
 <template>
-    <v-form v-slot="{ errors }" @submit="onSubmit">
-        <div class="mb-3">
-            <label for="email" class="form-label">帳號</label>
-            <v-field
-                id="email"
-                v-model="formData.email"
-                type="email"
-                class="form-control"
-                name="email"
-                :rules="playerLoginSchema.email"
-                :class="{ 'is-invalid': errors['email'] }"
-            ></v-field>
-            <error-message name="email" class="text-danger"></error-message>
-        </div>
+    <div class="login-wrap">
+        <v-form v-slot="{ errors }" @submit="onSubmit">
+            <div class="mb-3">
+                <label for="email" class="form-label require-icon">帳號</label>
+                <v-field
+                    id="email"
+                    v-model="formData.email"
+                    type="email"
+                    class="form-control"
+                    name="email"
+                    :rules="playerLoginSchema.email"
+                    :class="{ 'is-invalid': errors['email'] }"
+                ></v-field>
+                <error-message name="email" class="text-danger"></error-message>
+            </div>
 
-        <div class="mb-3">
-            <label for="password" class="form-label">密碼</label>
-            <v-field
-                id="password"
-                v-model="formData.password"
-                type="password"
-                class="form-control"
-                name="password"
-                :rules="playerLoginSchema.password"
-                :class="{ 'is-invalid': errors['password'] }"
-            ></v-field>
-            <error-message name="password" class="text-danger"></error-message>
-        </div>
+            <div class="mb-3">
+                <label for="password" class="form-label require-icon"
+                    >密碼</label
+                >
+                <div class="position-relative">
+                    <span
+                        class="material-symbols-outlined position-absolute eyes-icon"
+                        @click="togglePasswordVisibility('password')"
+                    >
+                        {{
+                            passwordFieldType === 'password'
+                                ? 'visibility_off'
+                                : 'visibility'
+                        }}
+                    </span>
+                    <v-field
+                        id="InputPassword1"
+                        v-model="formData.password"
+                        :type="passwordFieldType"
+                        class="form-control"
+                        rules="required|min:8|regex:(?=.*[A-Za-z])(?=.*\d)"
+                        placeholder="請輸入密碼"
+                        name="密碼"
+                        :class="{ 'is-invalid': errors['密碼'] }"
+                    ></v-field>
+                </div>
+                <error-message
+                    name="password"
+                    class="text-danger"
+                ></error-message>
+            </div>
 
-        <div class="password-forget d-flex justify-content-end mt-1">
-            <span class="text-muted" @click="goToForgetPasswordPage"
-                >忘記密碼
-            </span>
-        </div>
+            <div class="password-forget d-flex justify-content-end mt-1">
+                <span class="text-muted" @click="goToForgetPasswordPage"
+                    >忘記密碼
+                </span>
+            </div>
 
-        <div class="d-flex justify-content-center form-footer">
-            <button type="submit" class="btn btn-primary px-4 mt-4">
-                登入
-            </button>
-        </div>
-    </v-form>
+            <div class="d-flex justify-content-center form-footer">
+                <button type="submit" class="btn btn-primary px-4 mt-4">
+                    登入
+                </button>
+            </div>
+        </v-form>
+    </div>
 </template>
 <script>
 // import setUser from '@/stores/index';
@@ -100,7 +120,11 @@ export default defineComponent({
         // const { handleSubmit } = useForm({
         //     validationSchema: yup.object(playerLoginSchema),
         // });
-
+        const passwordFieldType = ref('password');
+        const togglePasswordVisibility = () => {
+            passwordFieldType.value =
+                passwordFieldType.value === 'password' ? 'text' : 'password';
+        };
         const onSubmitSuccess = async () => {
             try {
                 const response = await UserAPI.login({
@@ -170,7 +194,21 @@ export default defineComponent({
             playerLoginSchema,
             onSubmit,
             goToForgetPasswordPage,
+            togglePasswordVisibility,
+            passwordFieldType,
         };
     },
 });
 </script>
+<style lang="scss">
+.login-wrap .eyes-icon {
+    right: 16px;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    color: #9f9f9f;
+    &:hover {
+        color: #0088cc;
+    }
+}
+</style>

--- a/src/components/common/Login.vue
+++ b/src/components/common/Login.vue
@@ -21,7 +21,7 @@
                 >
                 <div class="position-relative">
                     <span
-                        class="material-symbols-outlined position-absolute eyes-icon"
+                        class="material-symbols-outlined position-absolute eyes-icon fs-8 me-2"
                         @click="togglePasswordVisibility('password')"
                     >
                         {{
@@ -207,6 +207,7 @@ export default defineComponent({
     transform: translate(-50%, -50%);
     cursor: pointer;
     color: #9f9f9f;
+
     &:hover {
         color: #0088cc;
     }

--- a/src/components/common/SingUp.vue
+++ b/src/components/common/SingUp.vue
@@ -23,7 +23,7 @@
                 >
                 <div class="position-relative">
                     <span
-                        class="material-symbols-outlined position-absolute eyes-icon"
+                        class="material-symbols-outlined position-absolute eyes-icon fs-8 me-2"
                         @click="togglePasswordVisibility('password')"
                     >
                         {{
@@ -54,7 +54,7 @@
                 >
                 <div class="position-relative">
                     <span
-                        class="material-symbols-outlined position-absolute eyes-icon"
+                        class="material-symbols-outlined position-absolute eyes-icon fs-8 me-2"
                         @click="togglePasswordVisibility('confirmPassword')"
                     >
                         {{
@@ -165,6 +165,7 @@ onMounted(() => {
     transform: translate(-50%, -50%);
     cursor: pointer;
     color: #9f9f9f;
+
     &:hover {
         color: #0088cc;
     }

--- a/src/components/common/SingUp.vue
+++ b/src/components/common/SingUp.vue
@@ -1,8 +1,10 @@
 <template>
-    <div>
+    <div class="sign-up-wrap">
         <v-form v-slot="{ errors }" @submit="onSubmit">
             <div class="mb-3">
-                <label for="InputEmail1" class="form-label">email</label>
+                <label for="InputEmail1" class="form-label require-icon"
+                    >email</label
+                >
                 <v-field
                     id="InputEmail1"
                     v-model="formData.email"
@@ -16,32 +18,61 @@
                 <error-message name="email" class="text-danger"></error-message>
             </div>
             <div class="mb-3">
-                <label for="InputPassword1" class="form-label">密碼</label>
-                <v-field
-                    id="InputPassword1"
-                    v-model="formData.password"
-                    type="password"
-                    class="form-control"
-                    rules="required|min:8|regex:(?=.*[A-Za-z])(?=.*\d)"
-                    name="密碼"
-                    :class="{ 'is-invalid': errors['密碼'] }"
-                ></v-field>
+                <label for="InputPassword1" class="form-label require-icon"
+                    >密碼</label
+                >
+                <div class="position-relative">
+                    <span
+                        class="material-symbols-outlined position-absolute eyes-icon"
+                        @click="togglePasswordVisibility('password')"
+                    >
+                        {{
+                            passwordFieldType === 'password'
+                                ? 'visibility_off'
+                                : 'visibility'
+                        }}
+                    </span>
+                    <v-field
+                        id="InputPassword1"
+                        v-model="formData.password"
+                        :type="passwordFieldType"
+                        class="form-control"
+                        rules="required|min:8|regex:(?=.*[A-Za-z])(?=.*\d)"
+                        placeholder="請輸入密碼"
+                        name="密碼"
+                        :class="{ 'is-invalid': errors['密碼'] }"
+                    ></v-field>
+                </div>
                 <p>密碼須包含 1 個英文， 1 個數字，且長度至少為 8 個字元</p>
                 <error-message name="密碼" class="text-danger"></error-message>
             </div>
             <div class="mb-3">
-                <label for="confirmInputPassword1" class="form-label"
+                <label
+                    for="confirmInputPassword1"
+                    class="form-label require-icon"
                     >再次確認密碼</label
                 >
-                <v-field
-                    id="confirmInputPassword1"
-                    type="password"
-                    class="form-control"
-                    placeholder="請輸入密碼"
-                    rules="required|confirmed:@密碼"
-                    name="確認密碼"
-                    :class="{ 'is-invalid': errors['確認密碼'] }"
-                ></v-field>
+                <div class="position-relative">
+                    <span
+                        class="material-symbols-outlined position-absolute eyes-icon"
+                        @click="togglePasswordVisibility('confirmPassword')"
+                    >
+                        {{
+                            confirmPasswordFieldType === 'password'
+                                ? 'visibility_off'
+                                : 'visibility'
+                        }}
+                    </span>
+                    <v-field
+                        id="confirmInputPassword1"
+                        :type="confirmPasswordFieldType"
+                        class="form-control"
+                        placeholder="請輸入密碼"
+                        rules="required|confirmed:@密碼"
+                        name="確認密碼"
+                        :class="{ 'is-invalid': errors['確認密碼'] }"
+                    ></v-field>
+                </div>
                 <error-message
                     name="確認密碼"
                     class="text-danger"
@@ -67,7 +98,8 @@ import { useRouter, useRoute } from 'vue-router';
 
 const role = ref(null);
 const BsModal = ref(null);
-
+const passwordFieldType = ref('password');
+const confirmPasswordFieldType = ref('password');
 const formData = ref({
     email: '',
     password: '',
@@ -109,7 +141,15 @@ const goPage = () => {
         signupResult.value = defaultError;
     }
 };
-
+const togglePasswordVisibility = (field) => {
+    if (field === 'password') {
+        passwordFieldType.value =
+            passwordFieldType.value === 'password' ? 'text' : 'password';
+    } else if (field === 'confirmPassword') {
+        confirmPasswordFieldType.value =
+            confirmPasswordFieldType.value === 'password' ? 'text' : 'password';
+    }
+};
 onMounted(() => {
     if (route.path.includes('player')) {
         role.value = 'player';
@@ -118,3 +158,15 @@ onMounted(() => {
     }
 });
 </script>
+<style lang="scss">
+.sign-up-wrap .eyes-icon {
+    right: 16px;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    color: #9f9f9f;
+    &:hover {
+        color: #0088cc;
+    }
+}
+</style>

--- a/src/views/player/admin/Checkout.vue
+++ b/src/views/player/admin/Checkout.vue
@@ -332,12 +332,5 @@ body {
     .sub-title {
         font-size: 1.5rem;
     }
-
-    .require-icon::before {
-        content: '*';
-        font-size: 0.75rem;
-        color: #dc3545;
-        margin-right: 4px;
-    }
 }
 </style>


### PR DESCRIPTION
<img width="1357" alt="image" src="https://github.com/hyxfish27/AttackOnGame/assets/125852208/252acf3f-9c2f-4df1-95cd-eb8c069e277b">
我要開發一個我自己非常需要的功能，哈哈哈哈
我很常輸入錯誤密碼...

<img width="1357" alt="image" src="https://github.com/hyxfish27/AttackOnGame/assets/125852208/68237070-a926-4ff1-94d2-00ccec126e45">
但這個不知道甜甜有沒有什麼想法，對於這兩個icon靠得很近的部分...

<img width="776" alt="image" src="https://github.com/hyxfish27/AttackOnGame/assets/125852208/972b1341-69a6-472f-bc72-a85b7cd4e44d">
然後這然後這兩個不是一樣嗎～～哈哈哈，我有空可以改改，但我想說可以等全站modal都做好再復用