### PR TITLE
feat:修正玩家頁面上的分頁設計

### DIFF
--- a/src/components/common/Pagination.vue
+++ b/src/components/common/Pagination.vue
@@ -75,20 +75,30 @@ export default {
     .page-item .page-link {
         border-color: #333333 !important;
     }
+
+    .page-item .page-link:hover {
+        background-color: #0088cc;
+        color: #fff;
+    }
+
     .page-item.active {
         border: none;
     }
+
     .page-item.disabled .page-link {
         pointer-events: none;
-        color: #9f9f9f;
         background-color: #e9e9e9;
-        border-color: #e9e9e9 !important;
         opacity: 0.6;
     }
+
     .page-item.active .page-link {
         background-color: #0088cc;
         border-color: #0088cc !important;
         color: white;
+    }
+
+    .page-item.active .page-link:hover {
+        background-color: #005580 !important;
     }
 }
 </style>

--- a/src/components/common/Pagination.vue
+++ b/src/components/common/Pagination.vue
@@ -1,5 +1,5 @@
 <template>
-    <ul class="pagination justify-content-end m-auto">
+    <ul class="pagination pagination-wrap justify-content-end m-auto">
         <li class="page-item me-3" :class="{ disabled: currentPage === 1 }">
             <a
                 class="page-link"
@@ -70,14 +70,25 @@ export default {
 };
 </script>
 
-<style scoped>
-.page-item.disabled .page-link {
-    pointer-events: none;
-    opacity: 0.6;
-}
-.page-item.active .page-link {
-    background-color: #0088cc;
-    border-color: #0088cc;
-    color: white;
+<style lang="scss">
+.pagination-wrap {
+    .page-item .page-link {
+        border-color: #333333 !important;
+    }
+    .page-item.active {
+        border: none;
+    }
+    .page-item.disabled .page-link {
+        pointer-events: none;
+        color: #9f9f9f;
+        background-color: #e9e9e9;
+        border-color: #e9e9e9 !important;
+        opacity: 0.6;
+    }
+    .page-item.active .page-link {
+        background-color: #0088cc;
+        border-color: #0088cc !important;
+        color: white;
+    }
 }
 </style>

--- a/src/components/common/Pagination.vue
+++ b/src/components/common/Pagination.vue
@@ -1,0 +1,83 @@
+<template>
+    <ul class="pagination justify-content-end m-auto">
+        <li class="page-item me-3" :class="{ disabled: currentPage === 1 }">
+            <a
+                class="page-link"
+                href="#"
+                aria-label="Previous"
+                @click.prevent="prevPage"
+            >
+                <span aria-hidden="true">&lt;</span>
+            </a>
+        </li>
+        <li
+            v-for="page in totalPages"
+            :key="page"
+            class="page-item"
+            :class="{ active: page === currentPage }"
+        >
+            <a
+                class="page-link rounded me-3 border-dark"
+                href="#"
+                @click.prevent="goToPage(page)"
+                >{{ page }}</a
+            >
+        </li>
+        <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+            <a
+                class="page-link"
+                href="#"
+                aria-label="Next"
+                @click.prevent="nextPage"
+            >
+                <span aria-hidden="true">&gt;</span>
+            </a>
+        </li>
+    </ul>
+</template>
+
+<script>
+export default {
+    name: 'Pagination',
+    props: {
+        currentPage: {
+            type: Number,
+            required: true,
+        },
+        totalPages: {
+            type: Number,
+            required: true,
+        },
+    },
+    emits: ['update:currentPage'],
+    methods: {
+        prevPage() {
+            if (this.currentPage > 1) {
+                this.$emit('update:currentPage', this.currentPage - 1);
+            }
+        },
+        nextPage() {
+            if (this.currentPage < this.totalPages) {
+                this.$emit('update:currentPage', this.currentPage + 1);
+            }
+        },
+        goToPage(page) {
+            if (page !== this.currentPage) {
+                this.$emit('update:currentPage', page);
+            }
+        },
+    },
+};
+</script>
+
+<style scoped>
+.page-item.disabled .page-link {
+    pointer-events: none;
+    opacity: 0.6;
+}
+.page-item.active .page-link {
+    background-color: #0088cc;
+    border-color: #0088cc;
+    color: white;
+}
+</style>

--- a/src/components/player/ActivityTable.vue
+++ b/src/components/player/ActivityTable.vue
@@ -4,6 +4,7 @@ import { defineProps, ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import toLocalString from '@/utilities/toLocalString';
 import EmptyTable from '@/components/common/EmptyTable.vue';
+import Pagination from '@/components/common/Pagination.vue';
 
 const PaymentStatus = {
     pending: '尚未付款',
@@ -36,7 +37,6 @@ const formatTime = (start, end) => {
     const Date = dayjs(start).format('YYYY-MM-DD');
     const startTime = dayjs(start).format('HH:mm');
     const endTime = dayjs(end).format('HH:mm');
-
     return `${Date} ${startTime} ~ ${endTime}`;
 };
 
@@ -47,6 +47,9 @@ const goTicket = (idNumber) => {
         params: { idNumber },
     });
 };
+function handlePageChange(newPage) {
+    currentPage.value = newPage;
+}
 </script>
 
 <template>
@@ -124,49 +127,11 @@ const goTicket = (idNumber) => {
             </tbody>
         </table>
         <nav v-if="activityList.length > 0">
-            <ul class="pagination justify-content-end m-auto">
-                <li
-                    class="page-item me-3"
-                    :class="{ disabled: currentPage === 1 }"
-                >
-                    <a
-                        class="page-link"
-                        href="#"
-                        aria-label="Previous"
-                        @click.prevent="currentPage > 1 && currentPage--"
-                    >
-                        <span aria-hidden="true">&lt;</span>
-                    </a>
-                </li>
-                <li
-                    v-for="page in totalPages"
-                    :key="page"
-                    class="page-item"
-                    :class="{ active: page === currentPage }"
-                >
-                    <a
-                        class="page-link rounded me-3 border-dark"
-                        href="#"
-                        @click.prevent="currentPage = page"
-                        >{{ page }}</a
-                    >
-                </li>
-                <li
-                    class="page-item"
-                    :class="{ disabled: currentPage === totalPages }"
-                >
-                    <a
-                        class="page-link"
-                        href="#"
-                        aria-label="Next"
-                        @click.prevent="
-                            currentPage < totalPages && currentPage++
-                        "
-                    >
-                        <span aria-hidden="true">&gt;</span>
-                    </a>
-                </li>
-            </ul>
+            <Pagination
+                :current-page="currentPage"
+                :total-pages="totalPages"
+                @update:currentPage="handlePageChange"
+            />
         </nav>
     </div>
 </template>

--- a/src/views/EventList.vue
+++ b/src/views/EventList.vue
@@ -36,7 +36,7 @@
                         <option :value="3">已滿團</option>
                     </select>
                 </div>
-                <div class="">
+                <div class="d-flex align-items-center">
                     <button
                         type="submit"
                         class="btn btn-primary mb-2"
@@ -44,6 +44,12 @@
                     >
                         排序按照： {{ sortBy.text }}
                     </button>
+                    <span
+                        class="material-symbols-outlined cursor text-primary"
+                        @click="changeSortOrder"
+                    >
+                        {{ sortOrderIcon }}
+                    </span>
                 </div>
             </div>
             <div v-if="loading" class="text-center mt-4">
@@ -52,25 +58,31 @@
             <div v-if="errorMessage.split()" class="text-center mt-4">
                 <p>{{ errorMessage }}</p>
             </div>
-            <div v-if="rawEventData.length > 0">
+            <div v-if="paginatedList.length > 0">
                 <EventPanel
                     class="mt-4"
-                    :data="rawEventData"
+                    :data="paginatedList"
                     :keywords="keywords"
                 ></EventPanel>
+                <Pagination
+                    :current-page="currentPage"
+                    :total-pages="totalPages"
+                    @update:currentPage="handlePageChange"
+                />
             </div>
         </div>
     </div>
 </template>
 <script setup>
 import EventAPI from '@/api/Event';
-// import CityAll from '@/utilities/city';
+import Pagination from '@/components/common/Pagination.vue';
 import { onMounted, ref, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import _debounce from 'lodash/debounce';
 import EventPanel from '../components/event/EventPanel.vue';
 import { SORT_BY, SORT_ORDER } from '../constant/eventList';
 
+const PER_PAGE = 8;
 const SORT_BY_MAP = {
     eventStartTime: {
         value: 'eventStartTime',
@@ -81,15 +93,23 @@ const SORT_BY_MAP = {
         text: '活動費用',
     },
 };
+const SORT_ORDER_ICON_MAP = {
+    desc: 'arrow_drop_down',
+    asc: 'arrow_drop_up',
+};
 const sortByKeys = Object.keys(SORT_BY_MAP);
 const sortBy = ref(SORT_BY_MAP[SORT_BY]);
-
+const sortOrder = ref(SORT_ORDER);
 function changeSortBy() {
     const currentIndex = sortByKeys.indexOf(sortBy.value.value);
     const nextIndex = (currentIndex + 1) % sortByKeys.length;
     sortBy.value = SORT_BY_MAP[sortByKeys[nextIndex]];
 }
-const sortOrder = ref(SORT_ORDER);
+function changeSortOrder() {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc';
+    return sortOrder.value;
+}
+const currentPage = ref(1);
 const loading = ref(true);
 const errorMessage = ref('');
 const inputValue = ref('');
@@ -98,7 +118,11 @@ const router = useRouter();
 const selectedType = ref('searchEvent');
 const selectedStatus = ref(0);
 const rawEventData = ref([]);
-
+const paginatedList = computed(() => {
+    const start = (currentPage.value - 1) * PER_PAGE;
+    const end = start + PER_PAGE;
+    return rawEventData.value.slice(start, end);
+});
 const getEvent = async (query = {}) => {
     loading.value = true;
     errorMessage.value = '';
@@ -119,7 +143,9 @@ const getEvent = async (query = {}) => {
 const registrationStatus = computed(() => {
     return selectedStatus.value !== 0 ? 2 : 0;
 });
-
+const sortOrderIcon = computed(() => {
+    return SORT_ORDER_ICON_MAP[sortOrder.value];
+});
 const query = computed(() => ({
     formationStatus: selectedStatus.value,
     registrationStatus: registrationStatus.value,
@@ -127,7 +153,12 @@ const query = computed(() => ({
     sortOrder: sortOrder.value,
     keyword: keywords.value,
 }));
-
+function handlePageChange(newPage) {
+    currentPage.value = newPage;
+}
+const totalPages = computed(() => {
+    return Math.ceil(rawEventData.value.length / PER_PAGE);
+});
 watch(
     query,
     (newQuery) => {

--- a/src/views/EventList.vue
+++ b/src/views/EventList.vue
@@ -45,7 +45,7 @@
                         排序按照： {{ sortBy.text }}
                     </button>
                     <span
-                        class="material-symbols-outlined cursor text-primary"
+                        class="material-symbols-outlined cursor text-primary pb-2"
                         @click="changeSortOrder"
                     >
                         {{ sortOrderIcon }}


### PR DESCRIPTION
<img width="1124" alt="image" src="https://github.com/hyxfish27/AttackOnGame/assets/125852208/4739b25a-26a3-405e-b5f9-c294485ffa11">
製作了排序的切換，可以由小往大排，也可以反著排
但我不太確定這樣設計的icon會不會太小，需要一雙專業的眼睛定奪

<img width="235" alt="image" src="https://github.com/hyxfish27/AttackOnGame/assets/125852208/a1c21991-2d29-4439-b1c1-e0715e8c8c43">
也增加了分頁的設計，這個配色我盡量還原設計稿的樣子，但可以調整（特別是指hover），看甜甜的感覺